### PR TITLE
call exit after logout

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -333,6 +333,7 @@ function saml_sls() {
 				wp_redirect(home_url());
 			}
 		}
+		exit();
 	} else {
 		echo __("SLS endpoint found an error.").$auth->getLastErrorReason();
 		return false;


### PR DESCRIPTION
saml_sls was not calling exit() after wp_redirect() which caused
execution to continue, and subsequent calls to single login
could cause the user to remain logged in.

Fixes: https://wordpress.org/support/topic/clicking-sign-out-doesnt-invalidate-session