### PR TITLE
Put a check if SAML Login message option is empty

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -21,7 +21,9 @@ function saml_checker() {
 
 function saml_custom_login_footer() {
 	$saml_login_message = get_option('onelogin_saml_customize_links_saml_login', "SAML Login");
-    echo '<div style="font-size: 110%;padding:8px;background: #fff;text-align: center;"><a href="'.get_site_url().'/wp-login.php?saml_sso">'.$saml_login_message.'</a></div>';
+	if (!empty($saml_login_message)) {
+		echo '<div style="font-size: 110%;padding:8px;background: #fff;text-align: center;"><a href="'.get_site_url().'/wp-login.php?saml_sso">'.$saml_login_message.'</a></div>';
+	}
 }
 
 function saml_load_translations() {


### PR DESCRIPTION
Currently, when SAML login message empty link is empty, it will show empty line at login page.  This PR is to check if it is empty, and do not `echo` when it is.