### PR TITLE
Fix Undefined `is_plugin_active` function

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -105,8 +105,9 @@ function saml_custom_login_footer() {
 	}
 
 	$login_page = 'wp-login.php';
-	if (is_plugin_active('wps-hide-login/wps-hide-login.php')) {
-		$login_page = str_replace( 'wp-login.php', get_site_option( 'whl_page', 'login' ), $login_page ) . '/';
+	$active_plugins = get_option( 'active_plugins' );
+	if ( is_array( $active_plugins ) && ! empty( $active_plugins ) && in_array( 'wps-hide-login/wps-hide-login.php', $active_plugins, true ) ) {
+		$login_page = str_replace( 'wp-login.php', esc_url( get_site_option( 'whl_page', 'login' ) ), $login_page ) . '/';
 	}
 	
 	$redirect_to = isset($_GET['redirect_to']) ? '&redirect_to='.$_GET['redirect_to'] : '';


### PR DESCRIPTION
When visiting the /wp-login.php page we've discovered that there is a fatal error emitted here:

![Screenshot 2023-12-21 at 12 42 01](https://github.com/onelogin/wordpress-saml/assets/75835774/bf4f6c4f-6938-43ec-ad4d-c6fbbfc440de)

This fix addresses that issue by replacing the is_plugin_active function with an alternative solution.

This issue also appears within Pantheon hosting, where the WP core files are slightly different from the standard WP installation.

Closes #135

Issue: https://github.com/onelogin/wordpress-saml/issues/129