### PR TITLE
Fix: allow users with a single-quote in username or email to login. 

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -313,8 +313,8 @@ function saml_acs() {
 		exit();
 	} else {
 		$userdata = array();
-		$userdata['user_login'] = wp_slash($username);
-		$userdata['user_email'] = wp_slash($email);
+		$userdata['user_login'] = wp_unslash($username);
+		$userdata['user_email'] = wp_unslash($email);
 	}
 
 	if (!empty($attrs)) {

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -325,8 +325,8 @@ function saml_acs() {
 		exit();
 	} else {
 		$userdata = array();
-		$userdata['user_login'] = wp_slash($username);
-		$userdata['user_email'] = wp_slash($email);
+		$userdata['user_login'] = wp_unslash($username);
+		$userdata['user_email'] = wp_unslash($email);
 	}
 
 	if (!empty($attrs)) {


### PR DESCRIPTION
Fixes https://github.com/SAML-Toolkits/wordpress-saml/issues/120
Tested in my environment, now ``gigi-d'agostino@example.com`` can login again :)

... I didn't know [that single quotes are valid in emails](https://stackoverflow.com/questions/4816424/are-single-quotes-legal-in-the-name-part-of-an-email-address) before.
