### PR TITLE
Fix `Call to undefined function is_plugin_active()`

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -99,6 +99,10 @@ function checkIsExternalURLAllowed($url, $trustedSites = [])
 }
 
 function saml_custom_login_footer() {
+	if (!function_exists('is_plugin_active')) {
+		include_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	
 	$saml_login_message = get_option('onelogin_saml_customize_links_saml_login');
 	if (empty($saml_login_message)) {
 		$saml_login_message = "SAML Login";


### PR DESCRIPTION
```
172.40.159.119 - - [10/Dec/2024:03:18:36 +0000] "GET /wp-admin/install.php HTTP/1.1" 200 1228                                                                                                                                                                                         
 [10-Dec-2024 03:18:46 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function is_plugin_active() in /bitnami/wordpress/wp-content/plugins/onelogin-saml-sso/php/functions.php:108                                                                                           
 Stack trace:                                                                                                                                                                                                                                                                          
#0 /opt/bitnami/wordpress/wp-includes/class-wp-hook.php(310): saml_custom_login_footer()                                                                                                                                                                                            
#1 /opt/bitnami/wordpress/wp-includes/plugin.php(205): WP_Hook->apply_filters()                                                                                                                                                                                                       
#2 /opt/bitnami/wordpress/wp-login.php(218): apply_filters()                                                                                                                                                                                                                          
#3 /opt/bitnami/wordpress/wp-login.php(1403): login_header()                                                                                                                                                                                                                          
#4 {main}                                                                                                                                                                                                                                                                             
  thrown in /bitnami/wordpress/wp-content/plugins/onelogin-saml-sso/php/functions.php on line 108 
```       

Fix `Call to undefined function is_plugin_active()`