### PR TITLE
Add opt-in 'Preserve existing roles' option to Role Mapping

### DIFF
--- a/onelogin-saml-sso/php/configuration.php
+++ b/onelogin-saml-sso/php/configuration.php
@@ -66,7 +66,8 @@ function onelogin_saml_configuration() {
 
 	$special_fields = array(
 		'onelogin_saml_role_mapping_multivalued_in_one_attribute_value',
-		'onelogin_saml_role_mapping_multivalued_pattern'
+		'onelogin_saml_role_mapping_multivalued_pattern',
+		'onelogin_saml_role_mapping_preserve_existing'
 	);
 
 	foreach ($fields as $section => $settings) {
@@ -265,6 +266,13 @@ function plugin_setting_boolean_onelogin_saml_role_mapping_multivalued_in_one_at
 	echo '<input type="checkbox" name="onelogin_saml_role_mapping_multivalued_in_one_attribute_value" id="onelogin_saml_role_mapping_multivalued_in_one_attribute_value"
 		  '.($value ? 'checked="checked"': '').'>
 		  <p class="description">'.__("Sometimes role values are provided in an unique attribute statement (instead multiple attribute statements). If that is the case, activate this and the plugin will try to split those values by ;<br>Use a regular expression pattern in order to extract complex data.", 'onelogin-saml-sso').'</p>';
+}
+
+function plugin_setting_boolean_onelogin_saml_role_mapping_preserve_existing($network = false) {
+	$value = $network ? get_site_option('onelogin_saml_role_mapping_preserve_existing') : get_option('onelogin_saml_role_mapping_preserve_existing');
+	echo '<input type="checkbox" name="onelogin_saml_role_mapping_preserve_existing" id="onelogin_saml_role_mapping_preserve_existing"
+		  '.($value ? 'checked="checked"': '').'>
+		  <p class="description">'.__("If enabled, roles resolved by the role mapping are only ever ADDED to the user: existing roles and per-user capabilities assigned in WordPress (e.g. via plugins like User Role Editor) are preserved on SSO login. Warning: roles revoked on the IdP side are NOT removed in WordPress, revoke them manually.", 'onelogin-saml-sso').'</p>';
 }
 
 function plugin_setting_string_onelogin_saml_role_mapping_multivalued_pattern($network = false) {
@@ -829,6 +837,11 @@ function get_onelogin_saml_settings_role_mapping() {
 	$fields['onelogin_saml_role_mapping_multivalued_pattern'] = array(
 		__('Regular expression for multiple role values', 'onelogin-saml-sso'),
 		'string'
+	);
+
+	$fields['onelogin_saml_role_mapping_preserve_existing'] = array(
+		__('Preserve existing roles', 'onelogin-saml-sso'),
+		'boolean'
 	);
 
 	return $fields;

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -660,6 +660,15 @@ function enroll_user_on_blogs($blog_id, $user_id, $roles) {
 function update_user_role($user_id, $roles)
 {
 	$user = get_user_by('id', $user_id);
+
+	if (get_option('onelogin_saml_role_mapping_preserve_existing', false)) {
+		// Keep roles and per-user capabilities assigned outside the role mapping
+		foreach($roles as $role) {
+			$user->add_role($role);
+		}
+		return;
+	}
+
 	$role = array_shift($roles);
 	$user->set_role($role);	// This removes previous assignations
 

--- a/onelogin-saml-sso/php/network.php
+++ b/onelogin-saml-sso/php/network.php
@@ -31,7 +31,8 @@ $option_group = 'onelogin_saml_configuration_network';
 	unset($fields['status']);
 	$special_fields = array(
 		'onelogin_saml_role_mapping_multivalued_in_one_attribute_value',
-		'onelogin_saml_role_mapping_multivalued_pattern'
+		'onelogin_saml_role_mapping_multivalued_pattern',
+		'onelogin_saml_role_mapping_preserve_existing'
 	);
 
 	foreach ($sections as $section => $description) {

--- a/onelogin-saml-sso/readme.txt
+++ b/onelogin-saml-sso/readme.txt
@@ -22,6 +22,9 @@ To mitigate that bug, place the script at the root of wordpress and execute it (
 
 == Changelog ==
 
+= 3.7.0 =
+* Add new "Preserve existing roles" option to the Role Mapping section. When enabled, roles resolved by the role mapping are only added to the user, preserving existing roles and per-user capabilities assigned in WordPress (e.g. via plugins like User Role Editor). Note that with this option enabled, roles revoked on the IdP side are not removed in WordPress.
+
 = 3.6.0 =
 * Update php-saml to 4.3.1 (PHP8 compatibility)
 


### PR DESCRIPTION
## Problem

When role mapping is configured, every SSO login runs `update_user_role()`, which calls `WP_User::set_role()`. `set_role()` **wipes all existing roles and per-user capabilities** before assigning the mapped role(s).

In practice this means any role or capability assigned inside WordPress — for example via plugins like **User Role Editor**, membership plugins, or manual admin assignment — is silently erased the next time the user logs in through SAML. The IdP becomes the only possible source of role assignments, which is not workable for sites that manage some roles in WordPress and only want the IdP to grant a baseline role.

## Solution

This PR adds an **opt-in** boolean setting, **"Preserve existing roles"** (`onelogin_saml_role_mapping_preserve_existing`), to the Role Mapping section:

- **Disabled (default):** behavior is unchanged — `set_role()` followed by `add_role()` for additional mapped roles, exactly as today.
- **Enabled:** `update_user_role()` only calls `add_role()` for each mapped role and returns. Existing roles and per-user capabilities are preserved.

The setting description states the trade-off explicitly: with this enabled, roles are only ever **added** by role mapping — roles revoked on the IdP side are **not** removed in WordPress and must be revoked manually.

## Changes

- `php/functions.php` — `update_user_role()` checks the new option and, when enabled, only adds the mapped roles.
- `php/configuration.php` — registers the new boolean option: added to the role-mapping `$special_fields`, a field definition next to the other role-mapping booleans, and a render function modeled on `plugin_setting_boolean_onelogin_saml_role_mapping_multivalued_in_one_attribute_value`.
- `php/network.php` — mirrors the setting in the multisite network settings form, following the existing handling of the other role-mapping special fields.
- `readme.txt` — changelog entry.

All changed files pass `php -l` (PHP 8.5), and the option name is used consistently across all files. No behavior change unless the new option is explicitly enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
